### PR TITLE
use callback to allow correct task dep definition

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,7 +109,7 @@ gulp.task('copystyles', function () {
 
 
 // Generate & Inline Critical-path CSS
-gulp.task('critical', ['build', 'copystyles'], function () {
+gulp.task('critical', ['build', 'copystyles'], function (cb) {
 
     // At this point, we have our
     // production styles in main/styles.css
@@ -128,7 +128,7 @@ gulp.task('critical', ['build', 'copystyles'], function () {
         width: 320,
         height: 480,
         minify: true
-    });
+    },cb);
 });
 
 


### PR DESCRIPTION
Update this to prevent copy & paste "errors" of this demo

Extract from the gulp api doc:

Note: Are your tasks running before the dependencies are complete? Make sure your dependency tasks are correctly using the async run hints: take in a callback or return a promise or event stream.

So your critical package doesn't return a promise ( \* but as it looks like it's easy to extend https://github.com/addyosmani/critical/blob/master/index.js )
