### PR TITLE
Update output demos HTML

### DIFF
--- a/output/critical/index.html
+++ b/output/critical/index.html
@@ -7,10 +7,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
-        <!-- styles/main.css is where we initially write all your CSS and then overwrite it with your critical path CSS. Your site-wide styles are in styles/site.css, which we async load in via JavaScript lower down in the page  -->
         <style type="text/css">
-html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}body{margin:0}a{background:0 0}h1{margin:.67em 0}@media print{*{color:#000!important;text-shadow:none!important;background:0 0!important;box-shadow:none!important}a{text-decoration:underline}a[href]:after{content:" (" attr(href)")"}a[href^="#"]:after{content:""}h3,p{orphans:3;widows:3}h3{page-break-after:avoid}}*,:after,:before{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}html{font-size:62.5%;-webkit-tap-highlight-color:transparent}body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line-height:1.42857143;color:#333;background-color:#fff}a{color:#428bca;text-decoration:none}h1,h3,h4{font-family:inherit;font-weight:500;line-height:1.1;color:inherit}h1,h3{margin-top:20px;margin-bottom:10px}h4{margin-top:10px;margin-bottom:10px}h1{font-size:36px}h3{font-size:24px}h4{font-size:18px}p{margin:0 0 10px}.lead{margin-bottom:20px;font-size:16px;font-weight:200;line-height:1.4}@media (min-width:768px){.lead{font-size:21px}}.text-muted{color:#999}ul{margin-top:0;margin-bottom:10px}.container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto}@media (min-width:768px){.container{width:750px}}@media (min-width:992px){.container{width:970px}}@media (min-width:1200px){.container{width:1170px}}.row{margin-right:-15px;margin-left:-15px}.col-lg-6{position:relative;min-height:1px;padding-right:15px;padding-left:15px}@media (min-width:1200px){.col-lg-6{float:left;width:50%}}.btn{display:inline-block;padding:6px 12px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.42857143;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:4px}.btn-success{color:#fff;background-color:#5cb85c;border-color:#4cae4c}.btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}.nav{padding-left:0;margin-bottom:0;list-style:none}.nav>li,.nav>li>a{position:relative;display:block}.nav>li>a{padding:10px 15px}.nav-pills>li{float:left}.nav-pills>li>a{border-radius:4px}.nav-pills>li+li{margin-left:2px}.nav-pills>li.active>a{color:#fff;background-color:#428bca}.jumbotron{padding:30px;margin-bottom:30px;background-color:#eee}.jumbotron,.jumbotron h1{color:inherit}.jumbotron p{margin-bottom:15px;font-size:21px;font-weight:200}.container .jumbotron{border-radius:6px}@media screen and (min-width:768px){.jumbotron{padding-top:48px;padding-bottom:48px}.container .jumbotron{padding-right:60px;padding-left:60px}.jumbotron h1{font-size:63px}}.container:after,.container:before,.nav:after,.nav:before,.row:after,.row:before{display:table;content:" "}.container:after,.nav:after,.row:after{clear:both}.pull-right{float:right!important}body{padding-top:20px;padding-bottom:20px}.header,.marketing{padding-left:15px;padding-right:15px}.header{border-bottom:1px solid #e5e5e5}.header h3{margin-top:0;margin-bottom:0;line-height:40px;padding-bottom:19px}.jumbotron{text-align:center;border-bottom:1px solid #e5e5e5}.jumbotron .btn{font-size:21px;padding:14px 24px}.marketing{margin:40px 0}@media screen and (min-width:768px){.container{max-width:730px}.header,.marketing{padding-left:0;padding-right:0}.header{margin-bottom:30px}.jumbotron{border-bottom:0}}
+.col-lg-6,.container{padding-right:15px;padding-left:15px}.btn,.jumbotron{text-align:center}html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;font-size:62.5%}body{margin:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line-height:1.42857143;color:#333;background-color:#fff;padding-top:20px;padding-bottom:20px}a{background:0 0;color:#428bca;text-decoration:none}h1{margin:.67em 0;font-size:36px}h1,h3,h4,ul{margin-bottom:10px}*,:after,:before{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}h1,h3,h4{font-family:inherit;font-weight:500;line-height:1.1;color:inherit}h1,h3{margin-top:20px}h4,ul{margin-top:10px}h3{font-size:24px}h4{font-size:18px}p{margin:0 0 10px}.header h3,ul{margin-top:0}.lead{margin-bottom:20px;font-size:16px;font-weight:200;line-height:1.4}.btn,.nav{margin-bottom:0}.text-muted{color:#999}.container{margin-right:auto;margin-left:auto}.row{margin-right:-15px;margin-left:-15px}.col-lg-6{position:relative;min-height:1px}.btn{display:inline-block;padding:6px 12px;font-size:14px;font-weight:400;line-height:1.42857143;white-space:nowrap;vertical-align:middle;background-image:none;border:1px solid transparent;border-radius:4px}.btn-success{color:#fff;background-color:#5cb85c;border-color:#4cae4c}.header,.jumbotron{border-bottom:1px solid #e5e5e5}.btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}.nav{padding-left:0;list-style:none}.nav>li,.nav>li>a{position:relative;display:block}.nav>li>a{padding:10px 15px}.nav-pills>li{float:left}.nav-pills>li>a{border-radius:4px}.nav-pills>li+li{margin-left:2px}.nav-pills>li.active>a{color:#fff;background-color:#428bca}.jumbotron{padding:30px;margin-bottom:30px;background-color:#eee}.jumbotron,.jumbotron h1{color:inherit}.jumbotron p{margin-bottom:15px;font-size:21px;font-weight:200}.container .jumbotron{border-radius:6px}.container:after,.container:before,.nav:after,.nav:before,.row:after,.row:before{display:table;content:" "}.container:after,.nav:after,.row:after{clear:both}.pull-right{float:right!important}@-ms-viewport{width:device-width}.header,.marketing{padding-left:15px;padding-right:15px}.header h3{margin-bottom:0;line-height:40px;padding-bottom:19px}.jumbotron .btn{font-size:21px;padding:14px 24px}.marketing{margin:40px 0}
 </style>
+<script id="loadcss">
+(function(u,s){!function(e){"use strict";var n=function(n,t,o){var l,r=e.document,i=r.createElement("link");if(t)l=t;else{var a=(r.body||r.getElementsByTagName("head")[0]).childNodes;l=a[a.length-1]}var d=r.styleSheets;i.rel="stylesheet",i.href=n,i.media="only x",l.parentNode.insertBefore(i,t?l:l.nextSibling);var f=function(e){for(var n=i.href,t=d.length;t--;)if(d[t].href===n)return e();setTimeout(function(){f(e)})};return i.onloadcssdefined=f,f(function(){i.media=o||"all"}),i};"undefined"!=typeof module?module.exports=n:e.loadCSS=n}("undefined"!=typeof global?global:this);for(var i in u){loadCSS(u[i],s);}}(['styles/main.css'],document.getElementById("loadcss")));
+</script>
 <noscript>
 <link rel="stylesheet" href="styles/main.css">
 </noscript>
@@ -32,7 +34,7 @@ html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:1
             </div>
 
             <div class="jumbotron">
-                <h1>&apos;Allo, &apos;Allo!</h1>
+                <h1>'Allo, 'Allo!</h1>
                 <p class="lead">Always a pleasure scaffolding your apps.</p>
                 <p><a class="btn btn-lg btn-success" href="#">Splendid!</a></p>
             </div>
@@ -48,7 +50,7 @@ html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:1
             </div>
 
             <div class="footer">
-                <p>&#x2665; from the Yeoman team</p>
+                <p>♥ from the Yeoman team</p>
             </div>
         </div>
 
@@ -66,16 +68,6 @@ html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:1
 
         <script src="scripts/plugins.js"></script>
 
-        <!-- Async load cross-site CSS, mostly interesting for production -->
-        <script>
-        function loadCSS(e,t,n){"use strict";var i=window.document.createElement("link");var o=t||window.document.getElementsByTagName("script")[0];i.rel="stylesheet";i.href=e;i.media="only x";o.parentNode.insertBefore(i,o);setTimeout(function(){i.media=n||"all"})}
-        loadCSS('styles/site.css');
-        </script>
-
-
         <script src="scripts/main.js"></script>
-<script>
-(function(d,u){for (var i in u) {var l=d.createElement('link');l.type='text/css';l.rel='stylesheet';l.href=u[i]; d.getElementsByTagName('head')[0].appendChild(l);}}(document,['styles/main.css']));
-</script>
 </body>
 </html>

--- a/output/normal/index.html
+++ b/output/normal/index.html
@@ -7,7 +7,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
-        <!-- styles/main.css is where we initially write all your CSS and then overwrite it with your critical path CSS. Your site-wide styles are in styles/site.css, which we async load in via JavaScript lower down in the page  -->
         <link rel="stylesheet" href="styles/main.css">
 
     </head>
@@ -60,13 +59,6 @@
         <script src="scripts/vendor.js"></script>
 
         <script src="scripts/plugins.js"></script>
-
-        <!-- Async load cross-site CSS, mostly interesting for production -->
-        <script>
-        function loadCSS(e,t,n){"use strict";var i=window.document.createElement("link");var o=t||window.document.getElementsByTagName("script")[0];i.rel="stylesheet";i.href=e;i.media="only x";o.parentNode.insertBefore(i,o);setTimeout(function(){i.media=n||"all"})}
-        loadCSS('styles/site.css');
-        </script>
-
 
         <script src="scripts/main.js"></script>
 </body>


### PR DESCRIPTION
So, i started looking at the two demos (normal page vs page using critical) and obviously the first i did was open the devtools to see the differences... but i noticed a few odd things : P

On https://addyosmani.com/critical-path-css-demo/output/normal/

* There is a site.css file being requested (returns 404) using loadCSS. There is actually another file named main.css that loads fine and has the styles for the page.

On https://addyosmani.com/critical-path-css-demo/output/critical/

* Same as before, an orphan site.css.
* The main.css file doesn't seem to be loaded via loadCSS (which is what the README mentions) but through a simpler js snippet that creates a link element and injects it.

So, i just ran the builds again, ```gulp``` for the normal page and ```gulp critical``` for the page with the inlined styles and copied the HTML files into the output folder which holds the demo pages.

The new HTML files score in pagespeed insights as expected and throw no errors:

## Normal

https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fimagentleman.github.io%2Fcritical-path-css-demo%2Foutput%2Fnormal%2F

## Critical

https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fimagentleman.github.io%2Fcritical-path-css-demo%2Foutput%2Fcritical%2F

And the critical example page has inlined styles, loadCSS asynchronously loads main.css and the noscript fallback is present, and the normal example page doesn't have any of the optimizations (no async css via loadCSS, etc).

This PR doesn't add anything major but might help avoid some confusion on newcomers (like me : S) to the library that inspect the HTML of the demos to see what it does and how it works.